### PR TITLE
[issue-304] Remove deprecated resetReadersToCheckpoint api

### DIFF
--- a/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
+++ b/src/main/java/io/pravega/connectors/flink/ReaderCheckpointHook.java
@@ -1,17 +1,19 @@
 /**
  * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.connectors.flink;
 
 import io.pravega.client.stream.Checkpoint;
+import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.impl.CheckpointImpl;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -34,26 +36,38 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Slf4j
 class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
 
-    /** The prefix of checkpoint names */
+    /**
+     * The prefix of checkpoint names
+     */
     private static final String PRAVEGA_CHECKPOINT_NAME_PREFIX = "PVG-CHK-";
 
-    /** Default thread pool size of the checkpoint scheduler */
+    /**
+     * Default thread pool size of the checkpoint scheduler
+     */
     private static final int DEFAULT_CHECKPOINT_THREAD_POOL_SIZE = 3;
 
     // ------------------------------------------------------------------------
 
-    /** The logical name of the operator. This is different from the (randomly generated)
+    /**
+     * The logical name of the operator. This is different from the (randomly generated)
      * reader group name, because it is used to identify the state in a checkpoint/savepoint
-     * when resuming the checkpoint/savepoint with another job. */
+     * when resuming the checkpoint/savepoint with another job.
+     */
     private final String hookUid;
 
-    /** The serializer for Pravega checkpoints, to store them in Flink checkpoints */
+    /**
+     * The serializer for Pravega checkpoints, to store them in Flink checkpoints
+     */
     private final CheckpointSerializer checkpointSerializer;
 
-    /** The reader group used to trigger and restore pravega checkpoints */
+    /**
+     * The reader group used to trigger and restore pravega checkpoints
+     */
     private final ReaderGroup readerGroup;
 
-    /** The timeout on the future returned by the 'initiateCheckpoint()' call */
+    /**
+     * The timeout on the future returned by the 'initiateCheckpoint()' call
+     */
     private final Time triggerTimeout;
 
     // The Pravega reader group config.
@@ -98,13 +112,13 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
         return checkpointResult;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void restoreCheckpoint(long checkpointId, Checkpoint checkpoint) throws Exception {
         // checkpoint can be null when restoring from a savepoint that
         // did not include any state for that particular reader name
         if (checkpoint != null) {
-            this.readerGroup.resetReadersToCheckpoint(checkpoint);
+            this.readerGroup.resetReaderGroup(ReaderGroupConfig.builder().disableAutomaticCheckpoints().
+                    startFromCheckpoint(checkpoint).build());
         }
     }
 
@@ -123,7 +137,7 @@ class ReaderCheckpointHook implements MasterTriggerRestoreHook<Checkpoint> {
         this.readerGroup.close();
 
         synchronized (scheduledExecutorLock) {
-            if (scheduledExecutorService != null ) {
+            if (scheduledExecutorService != null) {
                 log.info("Closing Scheduled Executor for hook {}", hookUid);
                 scheduledExecutorService.shutdownNow();
                 scheduledExecutorService = null;


### PR DESCRIPTION
**Change log description**

* Deleted the depcreated resetReadersToCheckpoint API
* modified ReaderCheckpointHookTest.java

**Purpose of the change**
fix #304

**What the code does**

* Deleted the depcreated `resetReadersToCheckpoint API`, use `resetReaderGroup#ReaderGroupConfig` instead 

*  New api needs CheckpointImpl to be added to Checkpoint
  
reference: [ReaderGroupConfigTest](https://github.com/pravega/pravega/blob/195f247cdfd8168c427ab76fb2040c5ae4689438/client/src/test/java/io/pravega/client/stream/ReaderGroupConfigTest.java)

**How to verify it**
`./gradlew clean build` passes